### PR TITLE
Json extensions

### DIFF
--- a/src/Testing.Commons/Serialization/JsonConverterExtensions.cs
+++ b/src/Testing.Commons/Serialization/JsonConverterExtensions.cs
@@ -65,7 +65,7 @@ public static class JsonConverterExtensions
 	/// </summary>
 	/// <param name="json">JSON text to parse.</param>
 	/// <returns>A <see cref="JsonObject"/> representation of the JSON value.</returns>
-	/// <exception cref="ArgumentException">The text provided by <paramref name="json"/> is not a <see cref="JsonObject"/>.</exception>
+	/// <exception cref="InvalidOperationException">The text provided by <paramref name="json"/> is not a <see cref="JsonObject"/>.</exception>
 	public static JsonObject ParseObject(this string json)
 	{
 		var nodeOpts = new JsonNodeOptions
@@ -76,7 +76,7 @@ public static class JsonConverterExtensions
 		JsonNode? objNode = JsonNode.Parse(json, nodeOpts);
 		if (objNode is null)
 		{
-			throw new ArgumentException($"String cannot be parsed as '{nameof(JsonObject)}'", nameof(json));
+			throw new InvalidOperationException($"The node must be of type '{nameof(JsonObject)}'");
 		}
 
 		JsonObject obj = objNode.AsObject();

--- a/src/Testing.Commons/Serialization/JsonConverterExtensions.cs
+++ b/src/Testing.Commons/Serialization/JsonConverterExtensions.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Testing.Commons.Serialization;
+
+/// <summary>
+/// Extension methods that provide help testing implementations of <see cref="JsonConverter{T}"/>.
+/// </summary>
+public static class JsonConverterExtensions
+{
+	/// <summary>
+	/// Writes the value to a string using the provided <see cref="JsonConverter" /> instance
+	/// </summary>
+	/// <typeparam name="T">The type of object or value handled by the converter.</typeparam>
+	/// <param name="subject">The converter being tested.</param>
+	/// <param name="toWrite">The instance to convert.</param>
+	/// <param name="options">An object that specifies serialization options to use or <c>null</c>.</param>
+	/// <returns>A string containing the JSON representation of <paramref name="toWrite"/> as specified by <paramref name="subject"/>.</returns>
+	public static string WriteToString<T>(this JsonConverter<T> subject, T toWrite, JsonSerializerOptions? options = null)
+	{
+		using var ms = new MemoryStream();
+		using var writer = new Utf8JsonWriter(ms);
+		
+		options ??= new JsonSerializerOptions()
+		{
+			Converters = { subject}
+		};
+		subject.Write(writer, toWrite, options);
+		writer.Flush();
+		var result = Encoding.UTF8.GetString(ms.ToArray());
+		return result;
+	}
+
+	/// <summary>
+	/// Reads the value using the provided <see cref="JsonConverter"/> from a JSON string.
+	/// </summary>
+	/// <typeparam name="T">The type of object or value handled by the converter.</typeparam>
+	/// <param name="subject">The converter being tested.</param>
+	/// <param name="json">The JSON representation of what the <paramref name="subject"/> will read.</param>
+	/// <param name="options">An object that specifies serialization options to use or <c>null</c>.</param>
+	/// <returns>The instance of <typeparamref name="T"/> read by <paramref name="subject"/>.</returns>
+	/// <exception cref="ArgumentException">The JSON string provided by <paramref name="json"/> could not be read by <paramref name="subject"/>.</exception>
+	public static T ReadFromString<T>(this JsonConverter<T> subject, string json, JsonSerializerOptions? options = null)
+	{
+		var bytes = Encoding.UTF8.GetBytes(json);
+		var reader = new Utf8JsonReader(bytes);
+		
+		reader.Read(); // advance before reading
+		options ??= new JsonSerializerOptions()
+		{
+			Converters = { subject}
+		};
+		var result = subject.Read(ref reader, typeof(T), options);
+		if (result is null)
+		{
+			throw new ArgumentException("Read value is 'null'", nameof(json));
+		}
+		return result;
+	}
+
+	/// <summary>
+	/// Parses text representing a single <see cref="JsonObject"/> value.
+	/// </summary>
+	/// <param name="json">JSON text to parse.</param>
+	/// <returns>A <see cref="JsonObject"/> representation of the JSON value.</returns>
+	/// <exception cref="ArgumentException">The text provided by <paramref name="json"/> is not a <see cref="JsonObject"/>.</exception>
+	public static JsonObject ParseObject(this string json)
+	{
+		var nodeOpts = new JsonNodeOptions
+		{
+			PropertyNameCaseInsensitive = true
+		};
+
+		JsonNode? objNode = JsonNode.Parse(json, nodeOpts);
+		if (objNode is null)
+		{
+			throw new ArgumentException($"String cannot be parsed as '{nameof(JsonObject)}'", nameof(json));
+		}
+
+		JsonObject obj = objNode.AsObject();
+		return obj;
+	}
+}
+

--- a/src/Testing.Commons/Testing.Commons.csproj
+++ b/src/Testing.Commons/Testing.Commons.csproj
@@ -30,10 +30,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>3.1.0.0</Version>
-		<AssemblyVersion>3.1.0.0</AssemblyVersion>
-		<FileVersion>3.1.0.0</FileVersion>
-		<PackageVersion>3.1.0.0</PackageVersion>
+		<Version>3.2.0.0</Version>
+		<AssemblyVersion>3.2.0.0</AssemblyVersion>
+		<FileVersion>3.2.0.0</FileVersion>
+		<PackageVersion>3.2.0.0</PackageVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Testing.Commons.Tests/Serialization/JsonConverterExtensionsTester.cs
+++ b/tests/Testing.Commons.Tests/Serialization/JsonConverterExtensionsTester.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using NUnit.Framework.Internal;
+using Testing.Commons.Serialization;
+using Testing.Commons.Tests.Serialization.Subjects;
+
+namespace Testing.Commons.Tests.Serialization;
+
+[TestFixture]
+public class JsonConverterExtensionsTester
+{
+	[Test]
+	public void WriteToString_NoOptions_JsonAsWrittenByConverter()
+	{
+		var subject = new CustomDoublingConverter();
+		var doubling = new Doubling(2);
+
+		string json = subject.WriteToString(doubling);
+
+		Assert.That(json, Is.EqualTo("4"), "by default, numbers are numbers");
+	}
+
+	[Test]
+	public void WriteToString_CustomOptions_OptionsAppliedToSerialization()
+	{
+		var subject = new CustomDoublingConverter();
+		var doubling = new Doubling(2);
+		var customOptions = new JsonSerializerOptions
+		{
+			NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.WriteAsString,
+		};
+
+		string json = subject.WriteToString(doubling, customOptions);
+
+		Assert.That(json, Is.EqualTo("\"4\""), "with the provided custom options, numbers are written as strings :-O");
+	}
+
+	[Test]
+	public void ReadFromString_NoOptions_JsonAsReadByConverter()
+	{
+		string json = "4";
+		var subject = new CustomDoublingConverter();
+
+		Doubling read = subject.ReadFromString(json);
+
+		Assert.That(read.Value, Is.EqualTo(2), "by default, numbers are numbers");
+	}
+
+	[Test]
+	public void WriteToString_CustomOptions_OptionsAppliedToDeserialization()
+	{
+		var subject = new CustomDoublingConverter();
+		string json = "\"4\"";
+		var customOptions = new JsonSerializerOptions
+		{
+			NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
+		};
+
+		Doubling read = subject.ReadFromString(json, customOptions);
+
+		Assert.That(read.Value, Is.EqualTo(2), "with the provided custom options, numbers are read as strings :-O");
+	}
+
+	[Test]
+	public void ParseObject_ObjectParseable_Parsed()
+	{
+		string json = """
+			{ "a": 1, "b": false}
+		""";
+
+		JsonObject obj = json.ParseObject();
+
+		Assert.That(obj, Has.Count.EqualTo(2), "two props");
+	}
+
+	[Test]
+	public void ParseObject_ObjectParseable_ParsedPropsAreCAseInsensitiveForEasyTesting()
+	{
+		string json = """
+			{ "a": 1, "b": false}
+		""";
+
+		JsonObject obj = json.ParseObject();
+
+		Assert.That(obj.ContainsKey("A"), Is.True);
+		Assert.That(obj["B"]!.GetValue<bool>(), Is.False);
+	}
+
+	[Test]
+	public void ParseObject_Null_Exception()
+	{
+		string json = "null";
+
+		Assert.That(() => json.ParseObject(), Throws.InvalidOperationException);
+	}
+	
+	[Test]
+	public void ParseObject_NotAnObject_Exception()
+	{
+		string json = "[1, false]";
+
+		Assert.That(()=> json.ParseObject(), Throws.InvalidOperationException);
+	}
+}

--- a/tests/Testing.Commons.Tests/Serialization/Subjects/CustomDoublingConverter.cs
+++ b/tests/Testing.Commons.Tests/Serialization/Subjects/CustomDoublingConverter.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Testing.Commons.Tests.Serialization.Subjects;
+
+/// <summary>
+///  Serializes the double (2x) amount of the provided number.
+/// </summary>
+internal class CustomDoublingConverter : JsonConverter<Doubling>
+{
+	public override Doubling Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		int doubledValue = JsonSerializer.Deserialize<int>(ref reader, options);
+		return new Doubling(doubledValue / 2);
+	}
+
+	public override void Write(Utf8JsonWriter writer, Doubling value, JsonSerializerOptions options)
+	{
+		JsonSerializer.Serialize(writer, value.Value * 2, options);
+	}
+}
+internal readonly record struct Doubling(int Value);
+


### PR DESCRIPTION
add `.WriteToString<>()`, `.ReadFromString<>()` and `.ParseObject()` utility extensions to make it easier to test custom converters and JSON serialization/deserialization